### PR TITLE
Use state array length variable inside for loop

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -143,7 +143,7 @@ impl App {
       };
 
       // draw all values
-      for index in 0..state.array.len() {
+      for index in 0..len {
         draw_value(index, VALUE_COLOR);
       }
 


### PR DESCRIPTION
In `gl.draw` fn scope we have defined `state.array.len()`.
We can make usege of this variable, and prevent read array length in every loop iteration. 